### PR TITLE
성장일기 태그 선택 화면 UI 구현

### DIFF
--- a/BBOXX-iOS/BBOXX-iOS.xcodeproj/project.pbxproj
+++ b/BBOXX-iOS/BBOXX-iOS.xcodeproj/project.pbxproj
@@ -75,6 +75,9 @@
 		6ACBC5B72723EE88002E1E55 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ACBC5B62723EE88002E1E55 /* OnboardingView.swift */; };
 		6AE861982727158E00D0619E /* OnboardingScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AE861972727158E00D0619E /* OnboardingScreen.swift */; };
 		6AE8619A272717B200D0619E /* OffsetPageTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AE86199272717B200D0619E /* OffsetPageTabView.swift */; };
+		6AEAB68F27398D6000D264CF /* Tags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AEAB68E27398D6000D264CF /* Tags.swift */; };
+		6AEAB69127398DE500D264CF /* TagCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AEAB69027398DE500D264CF /* TagCollectionView.swift */; };
+		6AEAB69327398E6F00D264CF /* SelectTagView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AEAB69227398E6F00D264CF /* SelectTagView.swift */; };
 		DD4210FBA9708BEA00AE62DB /* Pods_BBOXX_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 007B292E7C0B660A83EBD98B /* Pods_BBOXX_iOS.framework */; };
 /* End PBXBuildFile section */
 
@@ -151,6 +154,9 @@
 		6ACBC5B62723EE88002E1E55 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		6AE861972727158E00D0619E /* OnboardingScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingScreen.swift; sourceTree = "<group>"; };
 		6AE86199272717B200D0619E /* OffsetPageTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OffsetPageTabView.swift; sourceTree = "<group>"; };
+		6AEAB68E27398D6000D264CF /* Tags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tags.swift; sourceTree = "<group>"; };
+		6AEAB69027398DE500D264CF /* TagCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagCollectionView.swift; sourceTree = "<group>"; };
+		6AEAB69227398E6F00D264CF /* SelectTagView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectTagView.swift; sourceTree = "<group>"; };
 		EFDA4AFAF25925429B7FB3F5 /* Pods-BBOXX-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BBOXX-iOS.release.xcconfig"; path = "Target Support Files/Pods-BBOXX-iOS/Pods-BBOXX-iOS.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -271,6 +277,8 @@
 				458DEEFE272965840033B8CC /* GrowthNoteCollectionView.swift */,
 				458DEF0127296D640033B8CC /* GrowthNoteCell.swift */,
 				4596D1DE272A64CB00047C74 /* GrowthNoteDetailView.swift */,
+				6AEAB69027398DE500D264CF /* TagCollectionView.swift */,
+				6AEAB69227398E6F00D264CF /* SelectTagView.swift */,
 			);
 			path = GrowthNote;
 			sourceTree = "<group>";
@@ -332,6 +340,7 @@
 				45CE93502720FECF00ED60C5 /* Response.swift */,
 				6AE861972727158E00D0619E /* OnboardingScreen.swift */,
 				458DEF042729707A0033B8CC /* GrowthNote.swift */,
+				6AEAB68E27398D6000D264CF /* Tags.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -573,6 +582,7 @@
 				4551D8CA271574EE00EF8149 /* FeelingNoteWritingView.swift in Sources */,
 				45B1EA77272687CF006FC5F3 /* FeelingNoteResultView.swift in Sources */,
 				4527B84227083E0E003FD4F9 /* ContentView.swift in Sources */,
+				6AEAB68F27398D6000D264CF /* Tags.swift in Sources */,
 				4594B3172727C98400318B3B /* GrowthNoteResultView.swift in Sources */,
 				4597749F2734E85A003649F6 /* UserDefaults+Extension.swift in Sources */,
 				458DEF052729707A0033B8CC /* GrowthNote.swift in Sources */,
@@ -580,8 +590,10 @@
 				45AB2115271A9ECD00404122 /* NotificationCell.swift in Sources */,
 				45CE93512720FECF00ED60C5 /* Response.swift in Sources */,
 				6A5311BC2723EB8300B14768 /* SignInViewModel.swift in Sources */,
+				6AEAB69127398DE500D264CF /* TagCollectionView.swift in Sources */,
 				4589B58E272BDFAE00A5F60E /* DecibelMeasurementResultViewModel.swift in Sources */,
 				4589B58A272BD50000A5F60E /* DecibelMeasurementResultView.swift in Sources */,
+				6AEAB69327398E6F00D264CF /* SelectTagView.swift in Sources */,
 				457DA59B27302C2300A2F031 /* FeelingNoteDeleteCompleteView.swift in Sources */,
 				6AB89643272C777F006D35ED /* MainEmptySelectionView.swift in Sources */,
 				6A021258270A1CA0002828D9 /* FeelingNotes.swift in Sources */,

--- a/BBOXX-iOS/BBOXX-iOS/Models/Tags.swift
+++ b/BBOXX-iOS/BBOXX-iOS/Models/Tags.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct Tag: Identifiable, Hashable {
+    
+    var id = UUID().uuidString
+    var text: String
+    var size: CGFloat = 0
+}
+
+// Select Tags in Growth Note 
+struct TagList {
+    let tags = [
+    Tag(text: "나 왜그랬지"),
+    Tag(text: "지금은 행복해🥰"),
+    Tag(text: "나 열심히살았네"),
+    Tag(text: "이불킥 각"),
+    
+    Tag(text: "욕나온다"),
+    Tag(text: "아직도 열받아🤬"),
+    Tag(text: "개웃겨"),
+    Tag(text: "해탈😇"),
+    Tag(text: "노력중"),
+    
+    Tag(text: "내 맘이 단단해졌어💪"),
+    Tag(text: "할많하않"),
+    Tag(text: "미쳤다"),
+    Tag(text: "내 과거 안녕👋"),
+    
+    Tag(text: "ㅋ.."),
+    Tag(text: "똥밟았네💩"),
+    Tag(text: "별일 아니었어"),
+    Tag(text: "생각하고싶지않아😶"),
+    
+    
+    Tag(text: "이젠 괜찮아"),
+    Tag(text: "오히려 좋아"),
+    Tag(text: "머리터질듯🤯"),
+    Tag(text: "속이 뻥 뚫린듯"),
+    
+    ]
+}
+

--- a/BBOXX-iOS/BBOXX-iOS/Views/Scenes/GrowthNote/SelectTagView.swift
+++ b/BBOXX-iOS/BBOXX-iOS/Views/Scenes/GrowthNote/SelectTagView.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+struct SelectTagView: View {
+    
+    @State var tags: [Tag] = TagList().tags
+    @State var text: String = ""
+    var selectedCount = 0
+    @State var enableButton: Bool = false
+    
+    var body: some View {
+        VStack(spacing: 10) {
+            HStack {
+                NavigationLink(destination:
+                                MainView()
+                                .navigationBarHidden(true)) {
+                    Image(ImageAsset.backButton)
+                        .renderingMode(.template)
+                        .resizable()
+                        .frame(width: 24, height: 24)
+                        .foregroundColor(Color("BboxxGrayColor"))
+                        .frame(
+                            alignment: .topTrailing
+                        )
+                    
+                        .padding(.top, 16)
+                        .padding(.trailing, -8)
+                }
+                Spacer()
+            }
+            .background(
+                
+                Color("BboxxBackgroundColor")
+                    .ignoresSafeArea()
+            )
+            .padding(.leading, 20)
+            VStack(spacing: 80){
+                VStack(spacing: 10) {
+                    Text("지금 내 감정은..")
+                        .font(.system(size: 38, weight: .bold))
+                        .font(.custom("Pretendard-Bold", size: 24))
+                        .foregroundColor(Color("BboxxTextColor"))
+                        .frame(maxWidth: .infinity,alignment: .leading)
+                    Text("최대 다섯개까지 선택해봐")
+                        .font(.custom("Pretendard-SemiBold", size: 18))
+                        .foregroundColor(Color("BboxxTextColor"))
+                        .frame(maxWidth: .infinity,alignment: .leading)
+                }
+                
+                TagCollectionView(maxLimit: 150, tags: $tags, fontSize: 16)
+                    .frame(height: 280)
+                    .padding(.top,20)
+                Button {
+                } label: {
+                    Text("이 감정을 글로 써볼래")
+                        .fontWeight(.semibold)
+                        .foregroundColor(enableButton ? Color(.white) : Color("BboxxGrayColor"))
+                        .padding(.vertical,20)
+                        .padding(.horizontal,85)
+                        .background(enableButton ? Color("BboxxGrayColor") : Color(.white))
+                        .cornerRadius(10)
+                }
+                .frame(alignment: .bottom)
+                .padding(15)
+                .disabled(enableButton)
+                
+            }
+            .padding([.leading, .top], 20)
+            .frame(maxWidth: .infinity,maxHeight: .infinity, alignment: .top)
+            
+        }
+        .background(
+            
+            Color("BboxxBackgroundColor")
+                .ignoresSafeArea()
+        )
+    }
+}
+
+struct SelectTagView_Previews: PreviewProvider {
+    static var previews: some View {
+        SelectTagView()
+    }
+}

--- a/BBOXX-iOS/BBOXX-iOS/Views/Scenes/GrowthNote/SelectTagView.swift
+++ b/BBOXX-iOS/BBOXX-iOS/Views/Scenes/GrowthNote/SelectTagView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SelectTagView: View {
     
+    @Environment(\.presentationMode) var presentationMode
     @State var tags: [Tag] = TagList().tags
     @State var text: String = ""
     var selectedCount = 0
@@ -10,9 +11,9 @@ struct SelectTagView: View {
     var body: some View {
         VStack(spacing: 10) {
             HStack {
-                NavigationLink(destination:
-                                MainView()
-                                .navigationBarHidden(true)) {
+                Button(action: {
+                    presentationMode.wrappedValue.dismiss()
+                }) {
                     Image(ImageAsset.backButton)
                         .renderingMode(.template)
                         .resizable()

--- a/BBOXX-iOS/BBOXX-iOS/Views/Scenes/GrowthNote/TagCollectionView.swift
+++ b/BBOXX-iOS/BBOXX-iOS/Views/Scenes/GrowthNote/TagCollectionView.swift
@@ -1,0 +1,123 @@
+import SwiftUI
+
+struct TagCollectionView: View {
+
+    var maxLimit: Int
+    @Binding var tags: [Tag]
+    var fontSize: CGFloat = 16
+    
+    
+    var body: some View {
+       
+        VStack(alignment: .leading, spacing: 15) {
+            ScrollView(.horizontal, showsIndicators: false) {
+                
+                VStack(alignment: .leading, spacing: 20) {
+
+                    ForEach(getRows(),id: \.self){rows in
+                        
+                        HStack(spacing: 10){
+                            
+                            ForEach(rows){row in
+                                
+                                RowView(tag: row)
+                            }
+                        }
+                    }
+                }
+                .frame(alignment: .leading)
+                .padding(.vertical)
+                .padding(.bottom,20)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.leading, 10)
+        }
+    }
+    
+    @ViewBuilder
+    func RowView(tag: Tag) -> some View {
+        
+        Text(tag.text)
+            .font(.system(size: fontSize))
+            .padding(.horizontal,14)
+            .padding(.vertical,8)
+            .background(
+                Capsule()
+                    .fill(Color(.white))
+            )
+            .foregroundColor(Color("BboxxTextColor"))
+            .lineLimit(1)
+            .contentShape(Capsule())
+    }
+    
+    func getIndex(tag: Tag) -> Int {
+        
+        let index = tags.firstIndex { currentTag in
+            return tag.id == currentTag.id
+        } ?? 0
+        
+        return index
+    }
+    
+    func getRows() -> [[Tag]] {
+        
+        var rows: [[Tag]] = []
+        var currentRow: [Tag] = []
+        var totalWidth: CGFloat = 0
+        let screenWidth: CGFloat = UIScreen.main.bounds.width / 2.2
+        
+        tags.forEach { tag in
+            
+            totalWidth += (tag.size + 40)
+            
+            if totalWidth > screenWidth {
+                
+                totalWidth = (!currentRow.isEmpty || rows.isEmpty ? (tag.size + 40) : 0)
+                rows.append(currentRow)
+                currentRow.removeAll()
+                currentRow.append(tag)
+            } else {
+                currentRow.append(tag)
+            }
+        }
+        
+        if !currentRow.isEmpty{
+            rows.append(currentRow)
+            currentRow.removeAll()
+        }
+        
+        return rows
+    }
+}
+
+// MARK: Global Function
+func addTag(tags: [Tag],
+            text: String,
+            fontSize: CGFloat,
+            maxLimit: Int,
+            completion: @escaping (Bool,Tag)->()){
+    
+    let font = UIFont.systemFont(ofSize: fontSize)
+    
+    let attributes = [NSAttributedString.Key.font: font]
+    
+    let size = (text as NSString).size(withAttributes: attributes)
+    
+    let tag = Tag(text: text, size: size.width)
+    
+    if (getSize(tags: tags) + text.count) < maxLimit{
+        completion(false,tag)
+    }else{
+        completion(true,tag)
+    }
+}
+
+func getSize(tags: [Tag]) -> Int {
+    var count: Int = 0
+    
+    tags.forEach { tag in
+        count += tag.text.count
+    }
+    
+    return count
+}


### PR DESCRIPTION
## Done

- 기획서에 정의된 태그들을 가로 스크롤 가능
- 조건에 따라서 Button 배경/ 텍스트 색상 변경
- 뒤로가기 버튼 터치시 현재 화면 dismiss

## TODO

- 태그가 1~5개 선택시 버튼 활성화 조건인 enableButton 변경
- 선택된 태그 배경/ 텍스트 색상 변경
- "이 감정을 글로 써볼래" 버튼 터치시 다음 화면으로 이동


https://user-images.githubusercontent.com/52783516/140788965-507b8d4b-aa8c-4015-999c-be8ffc37d566.mov

related issue: #44

