### PR TITLE
감정일기 카테고리 선택 화면 UI 디테일 구현

### DIFF
--- a/BBOXX-iOS/BBOXX-iOS/Views/Scenes/FeelingNote/SelectCategoryView.swift
+++ b/BBOXX-iOS/BBOXX-iOS/Views/Scenes/FeelingNote/SelectCategoryView.swift
@@ -55,15 +55,6 @@ struct SelectCategoryView: View {
                         .foregroundColor(Color("BboxxTextColor"))
                         .frame(maxWidth: .infinity,alignment: .leading)
                     ZStack {
-                        if selectedCategory == "" {
-                            Text("\(selectedCategory)")
-                                .foregroundColor(Color(""))
-                                .padding(.leading, 15)
-                        } else {
-                            Text("\(defaultText)")
-                                .foregroundColor(Color(""))
-                                .padding(.leading, 15)
-                        }
                         
                     Button {
                         showPicker.toggle()
@@ -77,7 +68,21 @@ struct SelectCategoryView: View {
                     }
                     .frame(maxWidth: .infinity,
                            alignment: .leading)
+                        if selectedCategory != "" {
+                            Text("\(selectedCategory)")
+                                .foregroundColor(Color("BboxxTextColor"))
+                                .frame(maxWidth: .infinity,
+                                       alignment: .leading)
+                                .padding(.leading, 20)
+                        } else {
+                            Text("\(defaultText)")
+                                .foregroundColor(Color("BboxxTextColor"))
+                                .frame(maxWidth: .infinity,
+                                       alignment: .leading)
+                                .padding(.leading, 20)
+                        }
                     }
+                    
                     
                     Text("때문에 힘들어")
                         .font(.system(size: 30, weight: .bold))

--- a/BBOXX-iOS/BBOXX-iOS/Views/Scenes/FeelingNote/SelectCategoryView.swift
+++ b/BBOXX-iOS/BBOXX-iOS/Views/Scenes/FeelingNote/SelectCategoryView.swift
@@ -129,14 +129,32 @@ struct SelectCategoryView: View {
                 .padding(.bottom, 50)
                     
                     if showPicker {
-                        Picker("선택하기", selection: $selectedCategory) {
-                            ForEach(categories, id: \.self) { category in
-                                Text(category.rawValue)
+                        VStack {
+                            HStack {
+                                Spacer()
+                                Button {
+                                    showPicker = false
+                                    enableButton = true
+                                    print($selectedCategory)
+                                } label: {
+                                    Text("Done")
+                                        .font(.custom("Pretendard-Bold", size: 15))
+                                        .foregroundColor(Color("BboxxTextColor"))
+                                }
                             }
+                            .padding(.trailing, 30)
+                            .padding(.top, 30)
+                            
+                            Picker("선택하기", selection: $selectedCategory) {
+                                ForEach(categories, id: \.self) { category in
+                                    Text(category.rawValue).tag(category.rawValue)
+                                }
+                            }
+                            .background(Color(.white))
+                            .pickerStyle(WheelPickerStyle())
                         }
                         .background(Color(.white))
-                        .pickerStyle(WheelPickerStyle())
-                        
+                        .frame(width: .infinity, height: 150)
                     }
                 }
             }

--- a/BBOXX-iOS/BBOXX-iOS/Views/Scenes/FeelingNote/SelectCategoryView.swift
+++ b/BBOXX-iOS/BBOXX-iOS/Views/Scenes/FeelingNote/SelectCategoryView.swift
@@ -111,22 +111,27 @@ struct SelectCategoryView: View {
             VStack {
                 ZStack {
                     
-                    Button {
-                        self.tag = 1
-                        if selectedCategory != "" { enableButton = true }
-                        viewModel.selectCategoryId(selectedCategory)
-                    } label: {
-                        Text("다 골랐어")
-                            .fontWeight(.semibold)
-                            .foregroundColor(enableButton ? Color(.white) : Color("BboxxGrayColor").opacity(0.4))
-                        .padding(.vertical,20)
-                        .padding(.horizontal,120)
-                        .background(enableButton ? Color("BboxxGrayColor") : Color("disabledButtonColor"))
-                        .cornerRadius(16)
-                }
-                .disabled(enableButton == false)
-                .frame(alignment: .bottom)
-                .padding(.bottom, 50)
+                    NavigationLink(destination:
+                                    FeelingNoteWritingView()
+                                    .navigationBarHidden(true)) {
+                        Button {
+                            self.tag = 1
+                            if selectedCategory != "" { enableButton = true }
+                            viewModel.selectCategoryId(selectedCategory)
+                        } label: {
+                            Text("다 골랐어")
+                                .fontWeight(.semibold)
+                                .foregroundColor(enableButton ? Color(.white) : Color("BboxxGrayColor").opacity(0.4))
+                                .padding(.vertical,20)
+                                .padding(.horizontal,120)
+                                .background(enableButton ? Color("BboxxGrayColor") : Color("disabledButtonColor"))
+                                .cornerRadius(16)
+                            
+                        }
+                        .disabled(enableButton == false)
+                        .frame(alignment: .bottom)
+                        .padding(.bottom, 50)
+                    }
                     
                     if showPicker {
                         VStack {


### PR DESCRIPTION
## Done
1. Picker에 Done 버튼 추가하여 선택 완료 후 picker 화면 사라지도록 구현
2. 선택한 카테고리가 텍스트로 표시됨
3. 선택을 하지 않았을 경우 "다 골랐어" 버튼 비활성화. 선택한 경우 활성화
4. "다 골랐어" 버튼을 누른 경우 감정일기 작성 화면으로 전환

https://user-images.githubusercontent.com/52783516/141507537-9afee307-5628-4636-afb0-83b0c4ebd84a.mov



