### PR TITLE
성장일기 태그 뷰 레이아웃 변경 및 성장일기 작성 네트워크 연결

### DIFF
--- a/BBOXX-iOS/BBOXX-iOS/Views/Scenes/FeelingNote/FeelingNoteReviewView.swift
+++ b/BBOXX-iOS/BBOXX-iOS/Views/Scenes/FeelingNote/FeelingNoteReviewView.swift
@@ -70,7 +70,7 @@ struct FeelingNoteReviewView: View {
                     .padding(.top, 20)
                     
                     VStack { // SelectTagView로 넘어갈 때, 감정일기 id 값 넘겨줘야 함
-                        NavigationLink(destination: SelectTagView().navigationBarHidden(true)) {
+                        NavigationLink(destination: SelectTagView(feelingNoteId: self.feelingNote?.id ?? 0).navigationBarHidden(true)) {
                             Text("다시보니 괜찮아졌어")
                                 .font(.custom("Pretendard-SemiBold", size: 18))
                                 .foregroundColor(.white)

--- a/BBOXX-iOS/BBOXX-iOS/Views/Scenes/GrowthNote/SelectTagView.swift
+++ b/BBOXX-iOS/BBOXX-iOS/Views/Scenes/GrowthNote/SelectTagView.swift
@@ -50,10 +50,11 @@ struct SelectTagView: View {
                         
                         Spacer()
                         
-                        TagCollectionView(maxLimit: 150, tags: $tags, fontSize: 16)
-                            .frame(height: 280)
-                            
-                            .padding(.leading, -10)
+                        ScrollView() {
+                            TagCollectionView(tags: self.tags)
+                                .padding(.top, 20)
+                                .padding(.bottom, 20)
+                        }
                         
                         Spacer()
                         

--- a/BBOXX-iOS/BBOXX-iOS/Views/Scenes/GrowthNote/SelectTagView.swift
+++ b/BBOXX-iOS/BBOXX-iOS/Views/Scenes/GrowthNote/SelectTagView.swift
@@ -1,13 +1,13 @@
 import SwiftUI
 
 struct SelectTagView: View {
-    
+        
     @Environment(\.presentationMode) var presentationMode
-    @State var tags: [Tag] = TagList().tags
     @State var text: String = ""
-    var selectedCount = 0
-    @State var enableButton: Bool = false
     var feelingNoteId: Int = 0
+    
+    @State var selectedTags: [String] = []
+    @State var enableButton: Bool = true
     
     @State var tag: Int? = 0
     
@@ -51,16 +51,16 @@ struct SelectTagView: View {
                         Spacer()
                         
                         ScrollView() {
-                            TagCollectionView(tags: self.tags)
+                            TagCollectionView(selectedTags: $selectedTags, enableButton: $enableButton)
                                 .padding(.top, 20)
                                 .padding(.bottom, 20)
                         }
                         
                         Spacer()
                         
-                        // 선택된 태그들 같이 보내야 하는 코드 필요
+                        // 선택된 태그들 같이 보내는 코드 필요
                         NavigationLink(destination:
-                                        GrowthNoteWritingView()
+                                        GrowthNoteWritingView(feelingNoteId: self.feelingNoteId, tags: self.selectedTags)
                                         .navigationBarHidden(true), tag: 1, selection: $tag) {
                             EmptyView()
                         }
@@ -70,10 +70,10 @@ struct SelectTagView: View {
                         }, label: {
                             Text("이 감정을 글로 써볼래")
                                 .font(.custom("Pretendard-SemiBold", size: 18))
-                                .foregroundColor(.white)
+                                .foregroundColor(enableButton ? Color("BboxxGrayColor").opacity(0.4) : .white)
                         })
                         .frame(maxWidth: .infinity, maxHeight: 56)
-                        .background(Color("BboxxTextColor"))
+                        .background(enableButton ? Color("BboxxGrayColor").opacity(0.2) : Color("BboxxTextColor"))
                         .cornerRadius(16)
                         .disabled(enableButton)
                         

--- a/BBOXX-iOS/BBOXX-iOS/Views/Scenes/GrowthNote/TagCollectionView.swift
+++ b/BBOXX-iOS/BBOXX-iOS/Views/Scenes/GrowthNote/TagCollectionView.swift
@@ -1,10 +1,17 @@
 import SwiftUI
 
 struct TagCollectionView: View {
-    @State var tags: [Tag]
+    @State var tags: [Tag] = TagList().tags
     @State private var totalHeight = CGFloat.zero
     
-    @State var selectedTags: [String] = []
+    @Binding var selectedTags: [String]
+    @Binding var enableButton: Bool
+    
+    init(selectedTags: Binding<[String]>,
+         enableButton: Binding<Bool>) {
+        _selectedTags = selectedTags
+        _enableButton = enableButton
+    }
     
     var body: some View {
         VStack {
@@ -53,6 +60,8 @@ struct TagCollectionView: View {
             } else {
                 selectedTags.append(text)
             }
+            
+            self.checkButtonState()
         }, label: {
             Text(text)
                 .font(.custom("Pretendard-Medium", size: 16))
@@ -72,6 +81,17 @@ struct TagCollectionView: View {
                 binding.wrappedValue = rect.size.height
             }
             return .clear
+        }
+    }
+    
+    private func checkButtonState() {
+        switch selectedTags.count {
+        case 0:
+            enableButton = true
+        case 1...5:
+            enableButton = false
+        default:
+            enableButton = true
         }
     }
 }

--- a/BBOXX-iOS/BBOXX-iOS/Views/Scenes/GrowthNote/TagCollectionView.swift
+++ b/BBOXX-iOS/BBOXX-iOS/Views/Scenes/GrowthNote/TagCollectionView.swift
@@ -4,6 +4,8 @@ struct TagCollectionView: View {
     @State var tags: [Tag]
     @State private var totalHeight = CGFloat.zero
     
+    @State var selectedTags: [String] = []
+    
     var body: some View {
         VStack {
             GeometryReader { geometry in
@@ -46,15 +48,19 @@ struct TagCollectionView: View {
 
     private func item(for text: String) -> some View {
         Button(action: {
-            print("들어옴")
+            if selectedTags.contains(text) { // 갯수 제한 필요 최소 1, 최대 5
+                selectedTags.removeAll { $0 == text}
+            } else {
+                selectedTags.append(text)
+            }
         }, label: {
             Text(text)
                 .font(.custom("Pretendard-Medium", size: 16))
-                .foregroundColor(Color("BboxxGrayColor").opacity(0.6))
+                .foregroundColor(!self.selectedTags.contains(text) ? Color("BboxxGrayColor").opacity(0.6) : .white)
                 .padding()
                 .lineLimit(1)
         })
-        .background(Color(.white))
+        .background(!self.selectedTags.contains(text) ? Color(.white) : Color("BboxxTextColor"))
         .frame(height: 42)
         .cornerRadius(20)
     }

--- a/BBOXX-iOS/BBOXX-iOS/Views/Scenes/GrowthNote/TagCollectionView.swift
+++ b/BBOXX-iOS/BBOXX-iOS/Views/Scenes/GrowthNote/TagCollectionView.swift
@@ -1,124 +1,72 @@
 import SwiftUI
 
 struct TagCollectionView: View {
-
-    var maxLimit: Int
-    @Binding var tags: [Tag]
-    var fontSize: CGFloat = 16
-    
+    @State var tags: [Tag]
+    @State private var totalHeight = CGFloat.zero
     
     var body: some View {
-       
-        VStack(alignment: .leading, spacing: 15) {
-            ScrollView(.horizontal, showsIndicators: false) {
-                
-                VStack(alignment: .leading, spacing: 20) {
+        VStack {
+            GeometryReader { geometry in
+                self.generateContent(in: geometry)
+            }
+        }
+        .frame(height: totalHeight)
+    }
 
-                    ForEach(getRows(),id: \.self){rows in
-                        
-                        HStack(spacing: 10){
-                            
-                            ForEach(rows){row in
-                                
-                                RowView(tag: row)
-                            }
+    private func generateContent(in g: GeometryProxy) -> some View {
+        var width = CGFloat.zero
+        var height = CGFloat.zero
+        return ZStack(alignment: .topLeading) {
+            ForEach(tags.indices) { index in
+                item(for: tags[index].text)
+                    .padding([.horizontal, .vertical], 8)
+                    .alignmentGuide(.leading, computeValue: { d in
+                        if (abs(width - d.width) > g.size.width) {
+                            width = 0
+                            height -= d.height
                         }
-                    }
-                }
-                .frame(alignment: .leading)
-                .padding(.vertical)
-                .padding(.bottom,20)
+                        let result = width
+                        if tags[index] == self.tags.last! {
+                            width = 0 //last item
+                        } else {
+                            width -= d.width
+                        }
+                        return result
+                    })
+                    .alignmentGuide(.top, computeValue: {d in
+                        let result = height
+                        if tags[index] == self.tags.last! {
+                            height = 0 // last item
+                        }
+                        return result
+                    })
             }
-            .frame(maxWidth: .infinity)
-            .padding(.leading, 10)
-        }
+        }.background(viewHeightReader($totalHeight))
     }
-    
-    @ViewBuilder
-    func RowView(tag: Tag) -> some View {
-        
-        Text(tag.text)
-            .font(.custom("Pretendard-Medium", size: fontSize))
-            .foregroundColor(Color("BboxxGrayColor").opacity(0.6))
-            .padding(.horizontal,16)
-            .padding(.vertical,10)
-            .background(
-                Capsule()
-                    .fill(Color(.white))
-            )
-            .foregroundColor(Color("BboxxTextColor"))
-            .lineLimit(1)
-            .contentShape(Capsule())
+
+    private func item(for text: String) -> some View {
+        Button(action: {
+            print("들어옴")
+        }, label: {
+            Text(text)
+                .font(.custom("Pretendard-Medium", size: 16))
+                .foregroundColor(Color("BboxxGrayColor").opacity(0.6))
+                .padding()
+                .lineLimit(1)
+        })
+        .background(Color(.white))
+        .frame(height: 42)
+        .cornerRadius(20)
     }
-    
-    func getIndex(tag: Tag) -> Int {
-        
-        let index = tags.firstIndex { currentTag in
-            return tag.id == currentTag.id
-        } ?? 0
-        
-        return index
-    }
-    
-    func getRows() -> [[Tag]] {
-        
-        var rows: [[Tag]] = []
-        var currentRow: [Tag] = []
-        var totalWidth: CGFloat = 0
-        let screenWidth: CGFloat = UIScreen.main.bounds.width / 2.2
-        
-        tags.forEach { tag in
-            
-            totalWidth += (tag.size + 40)
-            
-            if totalWidth > screenWidth {
-                
-                totalWidth = (!currentRow.isEmpty || rows.isEmpty ? (tag.size + 40) : 0)
-                rows.append(currentRow)
-                currentRow.removeAll()
-                currentRow.append(tag)
-            } else {
-                currentRow.append(tag)
+
+    private func viewHeightReader(_ binding: Binding<CGFloat>) -> some View {
+        return GeometryReader { geometry -> Color in
+            let rect = geometry.frame(in: .local)
+            DispatchQueue.main.async {
+                binding.wrappedValue = rect.size.height
             }
+            return .clear
         }
-        
-        if !currentRow.isEmpty{
-            rows.append(currentRow)
-            currentRow.removeAll()
-        }
-        
-        return rows
     }
 }
 
-// MARK: Global Function
-func addTag(tags: [Tag],
-            text: String,
-            fontSize: CGFloat,
-            maxLimit: Int,
-            completion: @escaping (Bool,Tag)->()){
-    
-    let font = UIFont.systemFont(ofSize: fontSize)
-    
-    let attributes = [NSAttributedString.Key.font: font]
-    
-    let size = (text as NSString).size(withAttributes: attributes)
-    
-    let tag = Tag(text: text, size: size.width)
-    
-    if (getSize(tags: tags) + text.count) < maxLimit{
-        completion(false,tag)
-    }else{
-        completion(true,tag)
-    }
-}
-
-func getSize(tags: [Tag]) -> Int {
-    var count: Int = 0
-    
-    tags.forEach { tag in
-        count += tag.text.count
-    }
-    
-    return count
-}


### PR DESCRIPTION
### Done
- 성장일기 태그 뷰의 레이아웃을 변경하였습니다
기존 레이아웃은 버튼 클릭 후 좌우 스크롤 시, 클릭된 버튼이 초기화 되어지는 이슈가 있어 상하 스크롤로 수정하였습니다
- 선택된 태그 버튼이 0개일 경우 or 5개 초과 시, 하단 버튼이 비활성화 되고 1~5개일 시에는 하단 버튼이 활성화되는 조건을 추가하였습니다
- 성장일기 작성 쪽 네트워크를 연결하였습니다
성장일기 태그 선택 후, 성장일기 작성 시 태그 값도 같이 파라미터에 넣어 서버에 보내도록 구현하였습니다

### 스크린샷

https://user-images.githubusercontent.com/57670228/142793987-95ed772c-72af-45fd-8e75-ffaa7e033e9f.mov


