### PR TITLE
온보딩 화면 + 애플 로그인 + 앱 설정 수정

### DIFF
--- a/BBOXX-iOS/BBOXX-iOS.xcodeproj/project.pbxproj
+++ b/BBOXX-iOS/BBOXX-iOS.xcodeproj/project.pbxproj
@@ -932,7 +932,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.bboxx.BBOXX-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};
@@ -957,7 +957,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.bboxx.BBOXX-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};

--- a/BBOXX-iOS/BBOXX-iOS.xcodeproj/project.pbxproj
+++ b/BBOXX-iOS/BBOXX-iOS.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		6A02124D270A1BA9002828D9 /* APICall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A02124C270A1BA9002828D9 /* APICall.swift */; };
 		6A02125C270A1EBC002828D9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A02125B270A1EBC002828D9 /* AppDelegate.swift */; };
 		6A20E5E22723CBFF00876996 /* SignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A20E5E12723CBFF00876996 /* SignInView.swift */; };
+		6A357D8727527AD4005EBE41 /* SplashViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A357D8627527AD4005EBE41 /* SplashViewModel.swift */; };
 		6A4BC1D6274803E8001E83F2 /* SelectTagViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A4BC1D5274803E8001E83F2 /* SelectTagViewModel.swift */; };
 		6AB01FC2274005CF005012FB /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AB01FC1274005CF005012FB /* ImageLoader.swift */; };
 		6AB01FC42740062F005012FB /* AsyncImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AB01FC32740062F005012FB /* AsyncImage.swift */; };
@@ -196,6 +197,7 @@
 		6A02124C270A1BA9002828D9 /* APICall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APICall.swift; sourceTree = "<group>"; };
 		6A02125B270A1EBC002828D9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		6A20E5E12723CBFF00876996 /* SignInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInView.swift; sourceTree = "<group>"; };
+		6A357D8627527AD4005EBE41 /* SplashViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewModel.swift; sourceTree = "<group>"; };
 		6A4BC1D5274803E8001E83F2 /* SelectTagViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectTagViewModel.swift; sourceTree = "<group>"; };
 		6AB01FC1274005CF005012FB /* ImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
 		6AB01FC32740062F005012FB /* AsyncImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncImage.swift; sourceTree = "<group>"; };
@@ -534,6 +536,7 @@
 				456E5A4D273B84720051511D /* CreateNicknameViewModel.swift */,
 				456E5A4C273B84720051511D /* SignInViewModel.swift */,
 				6AC41441272C57B400935C43 /* OnboardingViewModel.swift */,
+				6A357D8627527AD4005EBE41 /* SplashViewModel.swift */,
 			);
 			path = Intro;
 			sourceTree = "<group>";
@@ -772,6 +775,7 @@
 				456E5A0B273B82A10051511D /* MyAuthenticator.swift in Sources */,
 				6ACBC5B52723EE67002E1E55 /* SplashView.swift in Sources */,
 				456E5A5D273B84BF0051511D /* FeelingNoteWritingViewModel.swift in Sources */,
+				6A357D8727527AD4005EBE41 /* SplashViewModel.swift in Sources */,
 				6ACBC5B32723ED70002E1E55 /* ImageAssets.swift in Sources */,
 				45B7B6872728EB15006B8B9E /* CustomTwoButton.swift in Sources */,
 				456E5A29273B83880051511D /* FeelingNoteWritingView.swift in Sources */,

--- a/BBOXX-iOS/BBOXX-iOS/BBOXX-iOS.entitlements
+++ b/BBOXX-iOS/BBOXX-iOS/BBOXX-iOS.entitlements
@@ -2,8 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key></key>
-	<string></string>
+	<key>aps-environment</key>
+	<string>development</string>
 	<key>com.apple.developer.applesignin</key>
 	<array>
 		<string>Default</string>

--- a/BBOXX-iOS/BBOXX-iOS/Helpers/SignIn/AppleSignInCoordinator.swift
+++ b/BBOXX-iOS/BBOXX-iOS/Helpers/SignIn/AppleSignInCoordinator.swift
@@ -1,4 +1,5 @@
 import AuthenticationServices
+import UIKit
 
 // Used in Sign In view model
 class AppleSignInCoordinator: NSObject, ASAuthorizationControllerDelegate {
@@ -34,27 +35,20 @@ class AppleSignInCoordinator: NSObject, ASAuthorizationControllerDelegate {
             
             // 토큰
             guard let appleToken = appleIDCredential.identityToken else { return }
-            do {
-                let token = try JSONDecoder().decode(String.self, from: appleToken)
-                // 로그인 요청
-                AuthService.shared.signIn(token, "APPLE") { result in
-                    switch result {
-                    case .success(let response):
-                        print(response)
-                    case .failure(let error):
-                        debugPrint("error occured: \(error)")
-                    }
-                }
-            } catch {
-                debugPrint("error occured: \(error)")
-            }
+            guard let token = String(data: appleToken, encoding: .utf8) else { return }
+            // 로그인 요청
+            self.signInViewModel.signIn(token, ProviderType.apple.rawValue)
         default:
             break
         }
     }
     
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
-        // TODO: add alert
+        let alert = UIAlertController()
+        alert.title = "로그인 실패"
+        alert.message = "다시 시도해주세요 🥺"
+        
+        // TODO: import Google Crashlytics Log
         print(error.localizedDescription)
     }
 }

--- a/BBOXX-iOS/BBOXX-iOS/Supporting Files/Info.plist
+++ b/BBOXX-iOS/BBOXX-iOS/Supporting Files/Info.plist
@@ -2,22 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>사진첩 접근을 허용하시겠습니까?</string>
-	<key>UIAppFonts</key>
-	<array>
-		<string>Pretendard-Thin.otf</string>
-		<string>Pretendard-SemiBold.otf</string>
-		<string>Pretendard-Regular.otf</string>
-		<string>Pretendard-Medium.otf</string>
-		<string>Pretendard-Light.otf</string>
-		<string>Pretendard-ExtraLight.otf</string>
-		<string>Pretendard-ExtraBold.otf</string>
-		<string>Pretendard-Bold.otf</string>
-		<string>Pretendard-Black.otf</string>
-	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
@@ -53,6 +37,8 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>
@@ -62,6 +48,20 @@
 	</dict>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>마이크 허용하시겠습니까?</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>사진첩 접근을 허용하시겠습니까?</string>
+	<key>UIAppFonts</key>
+	<array>
+		<string>Pretendard-Thin.otf</string>
+		<string>Pretendard-SemiBold.otf</string>
+		<string>Pretendard-Regular.otf</string>
+		<string>Pretendard-Medium.otf</string>
+		<string>Pretendard-Light.otf</string>
+		<string>Pretendard-ExtraLight.otf</string>
+		<string>Pretendard-ExtraBold.otf</string>
+		<string>Pretendard-Bold.otf</string>
+		<string>Pretendard-Black.otf</string>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
@@ -78,8 +78,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>

--- a/BBOXX-iOS/BBOXX-iOS/ViewModels/Intro/OnboardingViewModel.swift
+++ b/BBOXX-iOS/BBOXX-iOS/ViewModels/Intro/OnboardingViewModel.swift
@@ -24,4 +24,8 @@ class OnboardingViewModel: ObservableObject {
             }
         })
     }
+    
+    func isLastView(_ currentPage: Int) -> Bool {
+        return currentPage >= 5
+    }
 }

--- a/BBOXX-iOS/BBOXX-iOS/ViewModels/Intro/SplashViewModel.swift
+++ b/BBOXX-iOS/BBOXX-iOS/ViewModels/Intro/SplashViewModel.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+class SplashViewModel: ObservableObject {
+    
+    func checkFirstRun() -> Bool {
+        let userDefault = UserDefaults.standard
+        if userDefault.bool(forKey: "isFirstRun") {
+            userDefault.set(false, forKey: "isFirstRun")
+            return true
+        } else {
+            return false
+        }
+    }
+}

--- a/BBOXX-iOS/BBOXX-iOS/Views/Scenes/Intro/OnboardingPagerView.swift
+++ b/BBOXX-iOS/BBOXX-iOS/Views/Scenes/Intro/OnboardingPagerView.swift
@@ -6,6 +6,7 @@ struct OnboardingPagerView: View {
     @StateObject var page: Page = .first()
     @State var pageOffset: Double = 0
     @State var onboardingContetns = boardingScreens
+    @ObservedObject var viewModel = OnboardingViewModel()
     
     var data = Array(0..<6)
     
@@ -15,17 +16,13 @@ struct OnboardingPagerView: View {
                 Pager(page: self.page,
                       data: self.data,
                       id: \.self) { page in
-                    if pageOffset >= 5 {
-                        OnboardingLastView()
-                    } else {
-                        self.pageView(page)
-                    }
+                    self.pageView(page)
                 }
-                .pageOffset(pageOffset)
-                .swipeInteractionArea(.allAvailable)
+                      .pageOffset(pageOffset)
+                      .swipeInteractionArea(.allAvailable)
                 
                 NavigationLink(destination: SignInView().navigationBarHidden(true)) {
-                    Text("건너뛰기")
+                    Text(viewModel.isLastView(page.index) ? "시작하기" : "건너뛰기")
                         .font(.custom("Pretendard-Medium", size: 16))
                         .foregroundColor(Color("BboxxGrayColor").opacity(0.6))
                 }
@@ -40,16 +37,16 @@ struct OnboardingPagerView: View {
     func pageView(_ page: Int) -> some View {
         VStack(spacing: 60) {
             VStack(spacing: 60) {
-            let comment = onboardingContetns[page].comment
-            let image = onboardingContetns[page].image
-            Text("\(comment)")
-                .font(.custom("Pretendard-Bold", size: 24))
-                .foregroundColor(Color("BboxxTextColor"))
-                .multilineTextAlignment(.center)
-            Image(image)
-                .resizable()
-                .frame(width: 240, height: 240, alignment: .center)
-           
+                let comment = onboardingContetns[page].comment
+                let image = onboardingContetns[page].image
+                Text("\(comment)")
+                    .font(.custom("Pretendard-Bold", size: 24))
+                    .foregroundColor(Color("BboxxTextColor"))
+                    .multilineTextAlignment(.center)
+                Image(image)
+                    .resizable()
+                    .frame(width: 240, height: 240, alignment: .center)
+                
             }.frame(alignment: .top)
             
         }

--- a/BBOXX-iOS/BBOXX-iOS/Views/Scenes/Intro/SplashView.swift
+++ b/BBOXX-iOS/BBOXX-iOS/Views/Scenes/Intro/SplashView.swift
@@ -4,11 +4,16 @@ struct SplashView: View {
     
     @State var removeSplash1: Bool = false
     @State var removeSplash2: Bool = false
+    @ObservedObject var viewModel = SplashViewModel()
     
     var body: some View {
         
         ZStack{
-            OnboardingPagerView()
+            if viewModel.checkFirstRun() {
+                OnboardingPagerView()
+            } else {
+                SignInView()
+            }
             
             ZStack {
                 Color("BboxxGrayColor")


### PR DESCRIPTION
## Done
### Sign In With Apple
-  애플 로그인 실패 후 Alert 띄우기
- 애플 로그인 token 디코딩 수정
- 애플 로그인시 Sign In API 호출
-  애플 로그인 성공 후 받아온 token으로 SignIn API 호출 후 response 수신 확인 
-  애플 로그인 성공 후 닉네임 생성화면으로 전환

### 온보딩
- "건너뛰기" -> "시작하기" 로 변경
- 앱 첫 설치에만 온보딩 화면 보이도록

### 앱 설정
- iPhone ⭕️ iPad ❌
- Portrait(세로모드) ⭕️ LandScape(가로모드) ❌
- release1.0 브랜치에 있는 entitlements 추가

## TODO
 애플 로그인 API Status Code 500 에러 백엔드와 논의 필요

related issue: #65 #66