### PR TITLE
다크모드 시, 색상 반전되는 이슈 & 소리치기 결과 뷰 관련 이슈 수정

### DIFF
--- a/BBOXX-iOS/BBOXX-iOS.xcodeproj/project.pbxproj
+++ b/BBOXX-iOS/BBOXX-iOS.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		4527B84227083E0E003FD4F9 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4527B84127083E0E003FD4F9 /* ContentView.swift */; };
 		4527B84427083E11003FD4F9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4527B84327083E11003FD4F9 /* Assets.xcassets */; };
 		4527B84727083E11003FD4F9 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4527B84627083E11003FD4F9 /* Preview Assets.xcassets */; };
+		4561E19E275265E400F95747 /* CustomTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4561E19D275265E400F95747 /* CustomTextField.swift */; };
 		456E59E6273B81F70051511D /* ProviderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456E59E5273B81F70051511D /* ProviderType.swift */; };
 		456E59E9273B820B0051511D /* Value+Codable+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456E59E8273B820B0051511D /* Value+Codable+Extension.swift */; };
 		456E59F4273B82540051511D /* FeelingNoteResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456E59ED273B82540051511D /* FeelingNoteResponse.swift */; };
@@ -121,6 +122,7 @@
 		4527B84327083E11003FD4F9 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		4527B84627083E11003FD4F9 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		4527B84827083E11003FD4F9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4561E19D275265E400F95747 /* CustomTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextField.swift; sourceTree = "<group>"; };
 		456E59E5273B81F70051511D /* ProviderType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProviderType.swift; sourceTree = "<group>"; };
 		456E59E8273B820B0051511D /* Value+Codable+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Value+Codable+Extension.swift"; sourceTree = "<group>"; };
 		456E59ED273B82540051511D /* FeelingNoteResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeelingNoteResponse.swift; sourceTree = "<group>"; };
@@ -296,6 +298,7 @@
 				456E5A44273B84580051511D /* DecibelMeasurementResultViewModel.swift */,
 				456E5A43273B84580051511D /* DecibelMeasurementViewModel.swift */,
 				456E5A45273B84580051511D /* NotificationListViewModel.swift */,
+				4561E19D275265E400F95747 /* CustomTextField.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -699,6 +702,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4561E19E275265E400F95747 /* CustomTextField.swift in Sources */,
 				456E5A5C273B84BF0051511D /* FeelingNoteReviewViewModel.swift in Sources */,
 				456E5A15273B82B30051511D /* DecibelService.swift in Sources */,
 				456E5A05273B82940051511D /* MyRequestInterceptor.swift in Sources */,

--- a/BBOXX-iOS/BBOXX-iOS/Extensions/UserDefaults+Extension.swift
+++ b/BBOXX-iOS/BBOXX-iOS/Extensions/UserDefaults+Extension.swift
@@ -1,19 +1,21 @@
 import Foundation
+import UIKit
+
 extension UserDefaults {
 
-    private enum Keys {
-
-        static let nickName = "nickName"
-
-    }
-
-    class var nickNameKey: String {
-        get {
-            return UserDefaults.standard.string(forKey: Keys.nickName) ?? "사랑스러운딸기"
+    func colorForKey(key: String) -> UIColor? {
+        var color: UIColor?
+        if let colorData = data(forKey: key) {
+            color = NSKeyedUnarchiver.unarchiveObject(with: colorData) as? UIColor
         }
-        set {
-            UserDefaults.standard.set(newValue, forKey: Keys.nickName)
-        }
+        return color
     }
-
+    
+    func setColor(color: UIColor?, forKey key: String) {
+        var colorData: NSData?
+        if let color = color {
+            colorData = NSKeyedArchiver.archivedData(withRootObject: color) as NSData?
+        }
+        set(colorData, forKey: key)
+    }
 }

--- a/BBOXX-iOS/BBOXX-iOS/ViewModels/BottomCard.swift
+++ b/BBOXX-iOS/BBOXX-iOS/ViewModels/BottomCard.swift
@@ -74,7 +74,7 @@ struct BottomCard<Content: View>: View {
                 .background(Color.white)
                 .cornerRadius(24, corners: [.topLeft, .topRight])
 
-                .frame(minWidth: 0, maxWidth: .infinity, maxHeight: height)
+                .frame(maxWidth: .infinity, maxHeight: height)
                 .offset(y: cardDismissal && cardShown ? 0 : height)
                 .animation(Animation.default.delay(0.2))
                 
@@ -116,11 +116,15 @@ struct CardContent: View {
                 
                 .padding(.top, 8)
             
-            Image(ImageAsset.trashIcon)
-                .resizable()
-                .frame(width: 180, height: 180, alignment: .center)
+            HStack {
+                Image(ImageAsset.trashIcon)
+                    .resizable()
+                    .frame(maxWidth: 200, maxHeight: 200, alignment: .center)
+                    
+                    .padding(.top, 20)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
 
-                .padding(.top, 20)
             
         }
         

--- a/BBOXX-iOS/BBOXX-iOS/ViewModels/CustomTextField.swift
+++ b/BBOXX-iOS/BBOXX-iOS/ViewModels/CustomTextField.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct CustomTextField: View {
+    var placeholder: Text
+    @Binding var text: String
+    var editingChanged: (Bool)->() = { _ in }
+    var commit: ()->() = { }
+    
+    var body: some View {
+        ZStack(alignment: .leading) {
+            if text.isEmpty { placeholder }
+            TextField("", text: $text, onEditingChanged: editingChanged, onCommit: commit)
+        }
+    }
+}

--- a/BBOXX-iOS/BBOXX-iOS/ViewModels/DecibelMeasurementResultViewModel.swift
+++ b/BBOXX-iOS/BBOXX-iOS/ViewModels/DecibelMeasurementResultViewModel.swift
@@ -2,6 +2,20 @@ import SwiftUI
 import Photos
 
 class DecibelMeasurementResultViewModel: ObservableObject {
+    
+    var decibel: Int {
+        return UserDefaults.standard.integer(forKey: "decibel")
+    }
+    var decibelResultTitle: String {
+        return UserDefaults.standard.string(forKey: "decibelResultTitle") ?? ""
+    }
+    var decibelResultBgColor: UIColor {
+        return UserDefaults.standard.colorForKey(key: "decibelResultBgColor") ?? UIColor.white
+    }
+    var decibelResultImage: String {
+        return UserDefaults.standard.string(forKey: "decibelResultImage") ?? ""
+    }
+    
     func takeCapture() -> UIImage {
         var image: UIImage?
         guard let currentLayer = UIApplication.shared.windows.first(where: { $0.isKeyWindow })?.layer else { return UIImage() }

--- a/BBOXX-iOS/BBOXX-iOS/ViewModels/DecibelMeasurementViewModel.swift
+++ b/BBOXX-iOS/BBOXX-iOS/ViewModels/DecibelMeasurementViewModel.swift
@@ -17,7 +17,6 @@ class DecibelMeasurementViewModel: ObservableObject {
     var timeLeft = 3
     var secondsImage = ImageAsset.threeSeconds
     
-    @Published var tag: Int? = 0
     var title: String = ""
     var backgroundColor: Color = Color.white
     var decibelResultImage: String = ImageAsset.decibelResultImage1
@@ -87,7 +86,6 @@ class DecibelMeasurementViewModel: ObservableObject {
             case 0:
                 self.setDecibelMeasurementResultView()
                 self.postDecibel(decibel: Int(self.peak), memberId: KeychainWrapper.standard.integer(forKey: "memberId") ?? 0)
-                self.tag = 1
                 self.endMonitoring()
                 break
             default:
@@ -136,6 +134,11 @@ class DecibelMeasurementViewModel: ObservableObject {
             decibelResultImage = ImageAsset.decibelResultImage6
             break
         }
+        
+        UserDefaults.standard.set(Int(self.peak), forKey: "decibel")
+        UserDefaults.standard.set(self.title, forKey: "decibelResultTitle")
+        UserDefaults.standard.setColor(color: UIColor(backgroundColor), forKey: "decibelResultBgColor")
+        UserDefaults.standard.set(self.decibelResultImage, forKey: "decibelResultImage")
     }
     
     func postDecibel(decibel: Int, memberId: Int) {

--- a/BBOXX-iOS/BBOXX-iOS/Views/Scenes/DecibelMeasurementResultView.swift
+++ b/BBOXX-iOS/BBOXX-iOS/Views/Scenes/DecibelMeasurementResultView.swift
@@ -4,23 +4,9 @@ struct DecibelMeasurementResultView: View {
     
     @ObservedObject var viewModel = DecibelMeasurementResultViewModel()
     
-    var decibel: Int = 0
-    var title: String = ""
-    var backgroundColor: Color = Color.white
-    var decibelResultImage: String = ImageAsset.decibelResultImage1
-    
-    @Environment(\.presentationMode) var presentationMode
-
-    init(decibel: Float, title: String, backgroundColor: Color, decibelResultImage: String) {
-        self.decibel = Int(decibel)
-        self.title = title
-        self.backgroundColor = backgroundColor
-        self.decibelResultImage = decibelResultImage
-    }
-    
     var body: some View {
         ZStack {
-            Color(UIColor(backgroundColor)).ignoresSafeArea()
+            Color(UserDefaults.standard.colorForKey(key: "backgroundColor") ?? UIColor.white).ignoresSafeArea()
             
             VStack(alignment: .leading) {
                 HStack {
@@ -42,13 +28,13 @@ struct DecibelMeasurementResultView: View {
                 
                 Spacer()
                 
-                Text(title)
+                Text(UserDefaults.standard.string(forKey: "title") ?? "")
                     .font(.custom("Pretendard-Bold", size: 20))
                     .foregroundColor(.white)
                     .multilineTextAlignment(.leading)
                 
                 HStack {
-                    Text("\(self.decibel)")
+                    Text("\(UserDefaults.standard.integer(forKey: "decibel"))")
                         .font(.custom("Pretendard-SemiBold", size: 100))
                         .foregroundColor(.white)
                     
@@ -88,7 +74,7 @@ struct DecibelMeasurementResultView: View {
                 HStack {
                     Spacer()
                     
-                    Image(decibelResultImage)
+                    Image(UserDefaults.standard.string(forKey: "decibelResultImage") ?? "")
                         .resizable()
                         .frame(width: 199, height: 217)
                 }

--- a/BBOXX-iOS/BBOXX-iOS/Views/Scenes/DecibelMeasurementResultView.swift
+++ b/BBOXX-iOS/BBOXX-iOS/Views/Scenes/DecibelMeasurementResultView.swift
@@ -6,7 +6,7 @@ struct DecibelMeasurementResultView: View {
     
     var body: some View {
         ZStack {
-            Color(UserDefaults.standard.colorForKey(key: "backgroundColor") ?? UIColor.white).ignoresSafeArea()
+            Color(viewModel.decibelResultBgColor).ignoresSafeArea()
             
             VStack(alignment: .leading) {
                 HStack {
@@ -28,13 +28,13 @@ struct DecibelMeasurementResultView: View {
                 
                 Spacer()
                 
-                Text(UserDefaults.standard.string(forKey: "title") ?? "")
+                Text(viewModel.decibelResultTitle)
                     .font(.custom("Pretendard-Bold", size: 20))
                     .foregroundColor(.white)
                     .multilineTextAlignment(.leading)
                 
                 HStack {
-                    Text("\(UserDefaults.standard.integer(forKey: "decibel"))")
+                    Text("\(viewModel.decibel)")
                         .font(.custom("Pretendard-SemiBold", size: 100))
                         .foregroundColor(.white)
                     
@@ -74,7 +74,7 @@ struct DecibelMeasurementResultView: View {
                 HStack {
                     Spacer()
                     
-                    Image(UserDefaults.standard.string(forKey: "decibelResultImage") ?? "")
+                    Image(viewModel.decibelResultImage)
                         .resizable()
                         .frame(width: 199, height: 217)
                 }

--- a/BBOXX-iOS/BBOXX-iOS/Views/Scenes/DecibelMeasurementView.swift
+++ b/BBOXX-iOS/BBOXX-iOS/Views/Scenes/DecibelMeasurementView.swift
@@ -5,6 +5,7 @@ struct DecibelMeasurementView: View {
     @ObservedObject var viewModel = DecibelMeasurementViewModel()
     
     @State var showMic = true
+    @State var tag: Int? = 0
     
     @Environment(\.presentationMode) var presentationMode
     
@@ -43,18 +44,17 @@ struct DecibelMeasurementView: View {
                             .multilineTextAlignment(.center)
                     }
                     
-                    NavigationLink(destination: DecibelMeasurementResultView(
-                        decibel: self.viewModel.peak,
-                        title: self.viewModel.title,
-                        backgroundColor: self.viewModel.backgroundColor,
-                        decibelResultImage: self.viewModel.decibelResultImage
-                    )
-                    .navigationBarHidden(true), tag: 1, selection: self.$viewModel.tag) {
+                    NavigationLink(destination: DecibelMeasurementResultView().navigationBarHidden(true),
+                                   tag: 1, selection: self.$tag) {
                         EmptyView()
                     }
                     
                     Button(action: {
                         self.startMeasuring()
+                        
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                            self.tag = 1
+                        }
                     }) {
                         if showMic {
                             Image(ImageAsset.micButton)

--- a/BBOXX-iOS/BBOXX-iOS/Views/Scenes/FeelingNote/FeelingNoteResultView.swift
+++ b/BBOXX-iOS/BBOXX-iOS/Views/Scenes/FeelingNote/FeelingNoteResultView.swift
@@ -27,7 +27,6 @@ struct FeelingNoteResultView: View {
                     }
                 }
                 
-                Spacer()
                 
                 Text("\(viewModel.nickName)야,\n좀 후련해졌어?")
                     .font(.custom("Pretendard-Bold", size: 24))
@@ -41,6 +40,8 @@ struct FeelingNoteResultView: View {
                     .opacity(0.7)
                     
                     .padding(.top, 10)
+                
+                Spacer()
                 
                 HStack {
                     Spacer()

--- a/BBOXX-iOS/BBOXX-iOS/Views/Scenes/FeelingNote/FeelingNoteWritingView.swift
+++ b/BBOXX-iOS/BBOXX-iOS/Views/Scenes/FeelingNote/FeelingNoteWritingView.swift
@@ -14,6 +14,10 @@ struct FeelingNoteWritingView: View {
         
     @Environment(\.presentationMode) var presentationMode
     
+    init() {
+        UITextView.appearance().backgroundColor = .clear
+    }
+    
     var body: some View {
         NavigationView {
             ZStack {
@@ -88,8 +92,12 @@ struct FeelingNoteWritingView: View {
                         .padding(.leading, 24)
                         .padding(.trailing, 24)
                         
-                        TextField("지금 내 감정은..", text: $title)
+                        CustomTextField(
+                            placeholder: Text("지금 내 감정은..").foregroundColor(Color("BboxxGrayColor").opacity(0.2)),
+                            text: $title
+                        )
                             .font(.custom("Pretendard-Bold", size: 20))
+                            .foregroundColor(Color("BboxxTextColor"))
                             
                             .padding(.top, 16)
                             .padding(.leading, 24)
@@ -103,6 +111,7 @@ struct FeelingNoteWritingView: View {
                         TextEditor(text: $content)
                             .font(.custom("Pretendard-Regular", size: 16))
                             .foregroundColor(Color("BboxxTextColor"))
+                            .background(Color.white)
                             .onChange(of: content, perform: { value in
                                 self.viewModel.checkButtonState(title: title, content: content)
                             })

--- a/BBOXX-iOS/BBOXX-iOS/Views/Scenes/FeelingNote/FeelingNoteWritingView.swift
+++ b/BBOXX-iOS/BBOXX-iOS/Views/Scenes/FeelingNote/FeelingNoteWritingView.swift
@@ -96,12 +96,12 @@ struct FeelingNoteWritingView: View {
                             placeholder: Text("지금 내 감정은..").foregroundColor(Color("BboxxGrayColor").opacity(0.2)),
                             text: $title
                         )
-                            .font(.custom("Pretendard-Bold", size: 20))
-                            .foregroundColor(Color("BboxxTextColor"))
-                            
-                            .padding(.top, 16)
-                            .padding(.leading, 24)
-                            .padding(.trailing, 56)
+                        .font(.custom("Pretendard-Bold", size: 20))
+                        .foregroundColor(Color("BboxxTextColor"))
+                        
+                        .padding(.top, 16)
+                        .padding(.leading, 24)
+                        .padding(.trailing, 56)
                         
                         Divider()
                             .padding(.top, 10)

--- a/BBOXX-iOS/BBOXX-iOS/Views/Scenes/FeelingNote/SelectFeelingView.swift
+++ b/BBOXX-iOS/BBOXX-iOS/Views/Scenes/FeelingNote/SelectFeelingView.swift
@@ -35,6 +35,7 @@ struct SelectFeelingView: View {
                 
                 Text("지금 네 감정을\n이 중에서 골라볼래?")
                     .font(.custom("Pretendard-Bold", size: 24))
+                    .foregroundColor(Color("BboxxGrayColor"))
                     
                     .padding(.top, 23)
                     .padding(.leading, 24)

--- a/BBOXX-iOS/BBOXX-iOS/Views/Scenes/FeelingNote/SelectFeelingView.swift
+++ b/BBOXX-iOS/BBOXX-iOS/Views/Scenes/FeelingNote/SelectFeelingView.swift
@@ -62,7 +62,7 @@ struct SelectFeelingView: View {
                 
                 NavigationLink(destination: FeelingNoteRemindView(
                                 title: self.title ?? "",
-                                content: self.content ?? "", emotionStatusList: self.selectedEmotionIdList), tag: 1, selection: self.$tag) {
+                                content: self.content ?? "", emotionStatusList: self.selectedEmotionIdList).navigationBarHidden(true), tag: 1, selection: self.$tag) {
                     EmptyView()
                 }
                 

--- a/BBOXX-iOS/BBOXX-iOS/Views/Scenes/GrowthNote/GrowthNoteWritingView.swift
+++ b/BBOXX-iOS/BBOXX-iOS/Views/Scenes/GrowthNote/GrowthNoteWritingView.swift
@@ -18,6 +18,10 @@ struct GrowthNoteWritingView: View {
     
     @Environment(\.presentationMode) var presentationMode
     
+    init() {
+        UITextView.appearance().backgroundColor = .clear
+    }
+    
     var body: some View {
         NavigationView {
             ZStack {
@@ -92,12 +96,16 @@ struct GrowthNoteWritingView: View {
                         .padding(.leading, 24)
                         .padding(.trailing, 24)
                         
-                        TextField("지금 내 생각은..", text: $title)
-                            .font(.custom("Pretendard-Bold", size: 20))
-                            
-                            .padding(.top, 16)
-                            .padding(.leading, 24)
-                            .padding(.trailing, 56)
+                        CustomTextField(
+                            placeholder: Text("지금 내 생각은..").foregroundColor(Color("BboxxGrayColor").opacity(0.2)),
+                            text: $title
+                        )
+                        .font(.custom("Pretendard-Bold", size: 20))
+                        .foregroundColor(Color("BboxxTextColor"))
+                        
+                        .padding(.top, 16)
+                        .padding(.leading, 24)
+                        .padding(.trailing, 56)
                         
                         Divider()
                             .padding(.top, 10)
@@ -107,6 +115,7 @@ struct GrowthNoteWritingView: View {
                         TextEditor(text: $content)
                             .font(.custom("Pretendard-Regular", size: 16))
                             .foregroundColor(Color("BboxxTextColor"))
+                            .background(Color.white)
                             .onChange(of: content, perform: { value in
                                 self.viewModel.checkButtonState(title: title, content: content)
                             })

--- a/BBOXX-iOS/BBOXX-iOS/Views/Scenes/GrowthNote/GrowthNoteWritingView.swift
+++ b/BBOXX-iOS/BBOXX-iOS/Views/Scenes/GrowthNote/GrowthNoteWritingView.swift
@@ -8,9 +8,6 @@ struct GrowthNoteWritingView: View {
     @State private var title: String = ""
     @State private var content: String = ""
     
-    var feelingNoteId: Int = 0
-    var tags: [String] = []
-    
     @State private var cardShown: Bool = false
     @State private var cardDismissal: Bool = false
     
@@ -18,7 +15,13 @@ struct GrowthNoteWritingView: View {
     
     @Environment(\.presentationMode) var presentationMode
     
-    init() {
+    var feelingNoteId: Int = 0
+    var tags: [String] = []
+    
+    init(feelingNoteId: Int, tags: [String]) {
+        self.feelingNoteId = feelingNoteId
+        self.tags = tags
+        
         UITextView.appearance().backgroundColor = .clear
     }
     

--- a/BBOXX-iOS/BBOXX-iOS/Views/Scenes/Intro/CreateNicknameView.swift
+++ b/BBOXX-iOS/BBOXX-iOS/Views/Scenes/Intro/CreateNicknameView.swift
@@ -4,78 +4,83 @@ import SwiftKeychainWrapper
 struct CreateNicknameView: View {
     
     @ObservedObject var viewModel = CreateNicknameViewModel()
-        
+    
     var body: some View {
         NavigationView {
-            VStack {
-                Text("너를 뭐라고 부를까?")
-                    .font(.custom("Pretendard-Bold", size: 24))
-                    
-                    .padding(.top, 115)
-                
-                Text("나중에 프로필에서 다시 바꿀 수 있어")
-                    .font(.custom("Pretendard-Regular", size: 14))
-                    .foregroundColor(Color("BboxxGrayColor").opacity(0.6))
-                    
-                    .padding(.top, 11)
-                
-                Text(viewModel.nickname)
-                    .font(.custom("Pretendard-SemiBold", size: 20))
-                    .foregroundColor(Color("BboxxTextColor"))
-                    .multilineTextAlignment(.center)
-                    .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: 56)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 18)
-                            .stroke(Color("BboxxTextColor"), lineWidth: 2)
-                    )
-                    
-                    .padding(.top, 50)
-                
-                Button(action: {
-                    viewModel.redoButtonDidTap()
-                }) {
-                    Image(ImageAsset.redoButton)
-                        .frame(width: 20, height: 20)
-                        .foregroundColor(Color("BboxxGrayColor"))
+            ZStack {
+                Color("BboxxBackgroundColor").ignoresSafeArea()
+
+                VStack {
+                    Text("너를 뭐라고 부를까?")
+                        .font(.custom("Pretendard-Bold", size: 24))
+                        .foregroundColor(.black)
                         
-                        .padding(.trailing, 6)
+                        .padding(.top, 115)
                     
-                    Text("다시 고르기")
-                        .font(.custom("Pretendard-Bold", size: 16))
+                    Text("나중에 프로필에서 다시 바꿀 수 있어")
+                        .font(.custom("Pretendard-Regular", size: 14))
                         .foregroundColor(Color("BboxxGrayColor").opacity(0.6))
+                        
+                        .padding(.top, 11)
+                    
+                    Text(viewModel.nickname)
+                        .font(.custom("Pretendard-SemiBold", size: 20))
+                        .foregroundColor(Color("BboxxTextColor"))
+                        .multilineTextAlignment(.center)
+                        .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: 56)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 18)
+                                .stroke(Color("BboxxTextColor"), lineWidth: 2)
+                        )
+                        
+                        .padding(.top, 50)
+                    
+                    Button(action: {
+                        viewModel.redoButtonDidTap()
+                    }) {
+                        Image(ImageAsset.redoButton)
+                            .frame(width: 20, height: 20)
+                            .foregroundColor(Color("BboxxGrayColor"))
+                            
+                            .padding(.trailing, 6)
+                        
+                        Text("다시 고르기")
+                            .font(.custom("Pretendard-Bold", size: 16))
+                            .foregroundColor(Color("BboxxGrayColor").opacity(0.6))
+                    }
+                    .padding(.top, 20)
+                    
+                    Spacer()
+                    
+                    NavigationLink(destination:
+                                    MainView()
+                                    .navigationBarHidden(true)
+                                   , tag: 1, selection: self.$viewModel.tag) {
+                        EmptyView()
+                    }
+                    
+                    Button(action: {
+                        viewModel.signUp(KeychainWrapper.standard.string(forKey: "authData") ?? "",
+                                         viewModel.nickname,
+                                         UserDefaults.standard.string(forKey: "providerType") ?? "")
+                    }, label: {
+                        Text("마음에 들어")
+                            .font(.custom("Pretendard-SemiBold", size: 18))
+                            .foregroundColor(.white)
+                    })
+                    .frame(maxWidth: .infinity, maxHeight: 56)
+                    .background(Color("BboxxTextColor"))
+                    .cornerRadius(16)
+                    
+                    .padding(.bottom, 30)
                 }
-                .padding(.top, 20)
+                .padding(.leading, 24)
+                .padding(.trailing, 24)
                 
-                Spacer()
-                
-                NavigationLink(destination:
-                                MainView()
-                                .navigationBarHidden(true)
-                               , tag: 1, selection: self.$viewModel.tag) {
-                    EmptyView()
-                }
-                
-                Button(action: {
-                    viewModel.signUp(KeychainWrapper.standard.string(forKey: "authData") ?? "",
-                                     viewModel.nickname,
-                                     UserDefaults.standard.string(forKey: "providerType") ?? "")
-                }, label: {
-                    Text("마음에 들어")
-                        .font(.custom("Pretendard-SemiBold", size: 18))
-                        .foregroundColor(.white)
-                })
-                .frame(maxWidth: .infinity, maxHeight: 56)
-                .background(Color("BboxxTextColor"))
-                .cornerRadius(16)
-                
-                .padding(.bottom, 30)
             }
+            .navigationBarHidden(true)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             
-            .padding(.leading, 24)
-            .padding(.trailing, 24)
-            
-            .background(Color("BboxxBackgroundColor")).ignoresSafeArea()
         }
     }
 }


### PR DESCRIPTION
related issue: #64 #72 #73 

### Done
- 다크모드 시, 색상 반전되는 이슈를 수정하였습니다 (ex. 감정 일기 & 성장일기 작성 뷰, 감정 선택 뷰, 닉네임 생성 뷰)
- 다크모드 시, placeholder 색상 또한 반전되는 이슈가 있어 **CustomTextfield**를 따로 만들었습니다
- 소리치기 결과 뷰에서 앱 나갈 시, 소리치기 뷰로 돌아가는 버그를 고쳤습니다
- UserDefaults에 UIColor를 저장하기 위해 **UserDefaults+Extension**에 관련 메소드를 만들었습니다
- 감정 일기 상단 불필요한 공백을 없앴습니다
- 화면 크기에 맞춰 바텀 뷰 레이아웃을 조정하였습니다

### To do
- 닉네임 생성 화면 - 화면 첫 진입시 닉네임 보이지 않는 이슈 수정
- 감정 공유하기 시, 화면 캡쳐 후 관련 알럿 띄우기

### 관련 자료
- https://fdee.tistory.com/entry/Xcode-%EA%B8%B0%EB%8A%A5-%EC%83%89%EC%83%81%EC%BB%AC%EB%9F%AC%EA%B0%92-%EC%84%A0%ED%83%9D-%EC%A0%80%EC%9E%A5-%EB%B6%88%EB%9F%AC%EC%98%A4%EB%8A%94-%EB%B0%A9%EB%B2%95-select-save-get-color-data-UIColorPicker
- https://medium.com/app-makers/how-to-use-textfield-in-swiftui-2fc0ca00f75b